### PR TITLE
[Agent] remove .npm from pull request

### DIFF
--- a/.npm/_logs/2026-03-24T15_37_01_464Z-debug-0.log
+++ b/.npm/_logs/2026-03-24T15_37_01_464Z-debug-0.log
@@ -1,0 +1,16 @@
+0 verbose cli /usr/local/bin/node /usr/local/bin/npm
+1 info using npm@10.8.2
+2 info using node@v20.20.1
+3 silly config load:file:/usr/local/lib/node_modules/npm/npmrc
+4 silly config load:file:/tmp/agent-workspaces/impl-3c9b23fd-6053-4b02-9317-a7a8b99288d1/.npmrc
+5 silly config load:file:/usr/local/etc/npmrc
+6 verbose title npm root
+7 verbose argv "root" "--global"
+8 verbose logfile logs-max:10 dir:/tmp/agent-workspaces/impl-3c9b23fd-6053-4b02-9317-a7a8b99288d1/.npm/_logs/2026-03-24T15_37_01_464Z-
+9 verbose logfile /tmp/agent-workspaces/impl-3c9b23fd-6053-4b02-9317-a7a8b99288d1/.npm/_logs/2026-03-24T15_37_01_464Z-debug-0.log
+10 verbose cwd /tmp/agent-workspaces/impl-3c9b23fd-6053-4b02-9317-a7a8b99288d1
+11 verbose os Linux 6.8.0-60-generic
+12 verbose node v20.20.1
+13 verbose npm  v10.8.2
+14 verbose exit 0
+15 info ok


### PR DESCRIPTION
## Agent Task

remove .npm from pull request

## Implementation Plan

## Implementation Plan

### Context

`.npm` is an untracked npm cache directory (45 MB) in the repo root. It's not committed, but it's also not in `.gitignore`, making it easy to accidentally include in a PR. The fix is to add it to `.gitignore`.

### Files to Modify

1. **`.gitignore`** — Add `.npm/` entry to prevent the npm cache directory from ever being staged or committed.

### Step-by-Step Approach

1. Open `.gitignore` and append `.npm/` alongside the other ignored tool directories (`.vscode/`, `.idea/`).
2. Verify with `git status` that `.npm` no longer appears as an untracked file.
3. Commit the single-line change.

### Branch Name

```
agent/add-npm-to-gitignore
```

---
_Created by AI Wingman Agent_