### PR TITLE
fix: derive external name from bucket for id-less objectstorage framework resources

### DIFF
--- a/config/external_name.go
+++ b/config/external_name.go
@@ -6,10 +6,35 @@ package config
 
 import (
 	"github.com/crossplane/upjet/v2/pkg/config"
+	"github.com/pkg/errors"
 )
 
 // Version is the version of the resources to be reconciled.
 const Version = "v1alpha1"
+
+// bucketAsExternalName uses the bucket name as the external name for framework
+// resources whose schema defines no "id" attribute and imports by bucket name.
+var bucketAsExternalName = config.NewExternalNameFrom(config.IdentifierFromProvider,
+	config.WithGetExternalNameFn(func(_ config.GetExternalNameFn, tfstate map[string]any) (string, error) {
+		if bucket, ok := tfstate["bucket"].(string); ok && bucket != "" {
+			return bucket, nil
+		}
+		return "", errors.New(`cannot find attribute "bucket" in tfstate`)
+	}),
+)
+
+// bucketKeyAsExternalName uses "{bucket}/{key}" as the external name, matching
+// the upstream import format of framework resources without an "id" attribute.
+var bucketKeyAsExternalName = config.NewExternalNameFrom(config.IdentifierFromProvider,
+	config.WithGetExternalNameFn(func(_ config.GetExternalNameFn, tfstate map[string]any) (string, error) {
+		bucket, _ := tfstate["bucket"].(string)
+		key, _ := tfstate["key"].(string)
+		if bucket == "" || key == "" {
+			return "", errors.New(`cannot find attributes "bucket" and "key" in tfstate`)
+		}
+		return bucket + "/" + key, nil
+	}),
+)
 
 // TerraformPluginSDKExternalNameConfigs contains all external name configurations
 // belonging to Terraform Plugin SDKv2 resources to be reconciled
@@ -98,16 +123,16 @@ var TerraformPluginSDKExternalNameConfigs = map[string]config.ExternalName{
 // TerraformPluginFrameworkExternalNameConfigs will be used for plugin configured resources. not used yet
 var TerraformPluginFrameworkExternalNameConfigs = map[string]config.ExternalName{
 	"ionoscloud_s3_bucket":                                      config.NameAsIdentifier,
-	"ionoscloud_s3_bucket_policy":                               config.IdentifierFromProvider,
-	"ionoscloud_s3_bucket_versioning":                           config.IdentifierFromProvider,
-	"ionoscloud_s3_bucket_cors_configuration":                   config.IdentifierFromProvider,
-	"ionoscloud_s3_bucket_lifecycle_configuration":              config.IdentifierFromProvider,
-	"ionoscloud_s3_bucket_public_access_block":                  config.IdentifierFromProvider,
-	"ionoscloud_s3_bucket_website_configuration":                config.IdentifierFromProvider,
-	"ionoscloud_s3_bucket_object_lock_configuration":            config.IdentifierFromProvider,
-	"ionoscloud_s3_bucket_server_side_encryption_configuration": config.IdentifierFromProvider,
-	"ionoscloud_s3_object":                                      config.IdentifierFromProvider,
-	"ionoscloud_s3_object_copy":                                 config.IdentifierFromProvider,
+	"ionoscloud_s3_bucket_policy":                               bucketAsExternalName,
+	"ionoscloud_s3_bucket_versioning":                           bucketAsExternalName,
+	"ionoscloud_s3_bucket_cors_configuration":                   bucketAsExternalName,
+	"ionoscloud_s3_bucket_lifecycle_configuration":              bucketAsExternalName,
+	"ionoscloud_s3_bucket_public_access_block":                  bucketAsExternalName,
+	"ionoscloud_s3_bucket_website_configuration":                bucketAsExternalName,
+	"ionoscloud_s3_bucket_object_lock_configuration":            bucketAsExternalName,
+	"ionoscloud_s3_bucket_server_side_encryption_configuration": bucketAsExternalName,
+	"ionoscloud_s3_object":                                      bucketKeyAsExternalName,
+	"ionoscloud_s3_object_copy":                                 bucketKeyAsExternalName,
 	"ionoscloud_object_storage_accesskey":                       config.IdentifierFromProvider,
 	"ionoscloud_pg_cluster_v2":                                  config.IdentifierFromProvider,
 	"ionoscloud_inmemorydb_cluster_v2":                          config.IdentifierFromProvider,


### PR DESCRIPTION
### Description of your changes

Fixes #71

The Terraform Plugin Framework object storage resources for bucket configuration — `ionoscloud_s3_bucket_policy`, `_versioning`, `_cors_configuration`, `_lifecycle_configuration`, `_public_access_block`, `_website_configuration`, `_object_lock_configuration`, `_server_side_encryption_configuration` — and `ionoscloud_s3_object`/`_object_copy` define **no `id` attribute** in their schemas. They were configured with `config.IdentifierFromProvider`, whose default `GetExternalNameFn` reads `tfstate["id"]`, so every reconcile failed with:

```
failed to compute the external-name from the state map: cannot find id in tfstate
```

even though the underlying API call (e.g. `PutBucketPolicy`) succeeded — leaving the managed resources permanently unready and undeletable without manually removing the finalizer.

This PR derives the external name from the attributes that actually identify these resources, matching the upstream Terraform import formats:

- bucket-configuration resources → the bucket name (upstream imports via `ImportStatePassthroughID(path.Root("bucket"))`)
- `Object`/`ObjectCopy` → `{bucket}/{key}`

implemented via `config.NewExternalNameFrom(config.IdentifierFromProvider, config.WithGetExternalNameFn(...))`. Upjet's plugin-framework external client only injects/requires `id` when the framework schema declares one, so nothing else is needed.

`make generate` produces **no generated-code changes** for this — the fix is purely behavioral (no CRD/API changes), and `spec.forProvider.bucket` and its resolvable reference are unchanged.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make generate`, `go build ./... && go test ./...`, and golangci-lint v2.11.0 (the version CI uses) — all clean. Note: local `make lint` is currently broken on the `v2` branch independent of this PR (the Makefile pins `GOLANGCILINT_VERSION ?= 1.54.0` while `.golangci.yml` uses the `version: "2"` config format).

### How has this code been tested

- `make generate` — confirms zero drift in generated APIs/CRDs.
- `go build ./...`, `go test ./...`, golangci-lint v2.11.0: pass, 0 issues.
- Failure mode reproduced on provider v0.5.7 / Crossplane 2.3.4 / k3s against `s3.eu-central-3.ionoscloud.com` with both `objectstorage.ionoscloud.io` and `objectstorage.m.ionoscloud.io` `BucketPolicy` resources (create succeeds server-side, CR churns forever; deletion hangs on the finalizer).

[contribution process]: https://git.io/fj2m9
