### PR TITLE
fix: publish objectstorage Key/StorageAccesskey credentials as connection details

### DIFF
--- a/apis/cluster/objectstorage/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/cluster/objectstorage/v1alpha1/zz_generated.deepcopy.go
@@ -2896,11 +2896,6 @@ func (in *KeyObservation) DeepCopyInto(out *KeyObservation) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.SecretKey != nil {
-		in, out := &in.SecretKey, &out.SecretKey
-		*out = new(string)
-		**out = **in
-	}
 	if in.UserID != nil {
 		in, out := &in.UserID, &out.UserID
 		*out = new(string)
@@ -4877,11 +4872,6 @@ func (in *StorageAccesskeyObservation) DeepCopyInto(out *StorageAccesskeyObserva
 	}
 	if in.ID != nil {
 		in, out := &in.ID, &out.ID
-		*out = new(string)
-		**out = **in
-	}
-	if in.Secretkey != nil {
-		in, out := &in.Secretkey, &out.Secretkey
 		*out = new(string)
 		**out = **in
 	}

--- a/apis/cluster/objectstorage/v1alpha1/zz_key_terraformed.go
+++ b/apis/cluster/objectstorage/v1alpha1/zz_key_terraformed.go
@@ -21,7 +21,7 @@ func (mg *Key) GetTerraformResourceType() string {
 
 // GetConnectionDetailsMapping for this Key
 func (tr *Key) GetConnectionDetailsMapping() map[string]string {
-	return nil
+	return map[string]string{"secret_key": "status.atProvider.secretKey"}
 }
 
 // GetObservation of this Key

--- a/apis/cluster/objectstorage/v1alpha1/zz_key_types.go
+++ b/apis/cluster/objectstorage/v1alpha1/zz_key_types.go
@@ -41,10 +41,6 @@ type KeyObservation struct {
 
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
-	// (Computed)  The IONOS Object Storage Secret key.
-	// The Object Storage Secret key.
-	SecretKey *string `json:"secretKey,omitempty" tf:"secret_key,omitempty"`
-
 	// [string] The UUID of the user owning the IONOS Object Storage Key.
 	// The ID of the user that owns the key.
 	UserID *string `json:"userId,omitempty" tf:"user_id,omitempty"`

--- a/apis/cluster/objectstorage/v1alpha1/zz_storageaccesskey_terraformed.go
+++ b/apis/cluster/objectstorage/v1alpha1/zz_storageaccesskey_terraformed.go
@@ -21,7 +21,7 @@ func (mg *StorageAccesskey) GetTerraformResourceType() string {
 
 // GetConnectionDetailsMapping for this StorageAccesskey
 func (tr *StorageAccesskey) GetConnectionDetailsMapping() map[string]string {
-	return nil
+	return map[string]string{"secretkey": "status.atProvider.secretkey"}
 }
 
 // GetObservation of this StorageAccesskey

--- a/apis/cluster/objectstorage/v1alpha1/zz_storageaccesskey_types.go
+++ b/apis/cluster/objectstorage/v1alpha1/zz_storageaccesskey_types.go
@@ -40,10 +40,6 @@ type StorageAccesskeyObservation struct {
 
 	// (Computed)  The ID (UUID) of the AccessKey.
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
-
-	// (Computed)  The secret key of the Access key.
-	// The secret key of the Access key.
-	Secretkey *string `json:"secretkey,omitempty" tf:"secretkey,omitempty"`
 }
 
 type StorageAccesskeyParameters struct {

--- a/apis/namespaced/objectstorage/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/namespaced/objectstorage/v1alpha1/zz_generated.deepcopy.go
@@ -2896,11 +2896,6 @@ func (in *KeyObservation) DeepCopyInto(out *KeyObservation) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.SecretKey != nil {
-		in, out := &in.SecretKey, &out.SecretKey
-		*out = new(string)
-		**out = **in
-	}
 	if in.UserID != nil {
 		in, out := &in.UserID, &out.UserID
 		*out = new(string)
@@ -4877,11 +4872,6 @@ func (in *StorageAccesskeyObservation) DeepCopyInto(out *StorageAccesskeyObserva
 	}
 	if in.ID != nil {
 		in, out := &in.ID, &out.ID
-		*out = new(string)
-		**out = **in
-	}
-	if in.Secretkey != nil {
-		in, out := &in.Secretkey, &out.Secretkey
 		*out = new(string)
 		**out = **in
 	}

--- a/apis/namespaced/objectstorage/v1alpha1/zz_key_terraformed.go
+++ b/apis/namespaced/objectstorage/v1alpha1/zz_key_terraformed.go
@@ -21,7 +21,7 @@ func (mg *Key) GetTerraformResourceType() string {
 
 // GetConnectionDetailsMapping for this Key
 func (tr *Key) GetConnectionDetailsMapping() map[string]string {
-	return nil
+	return map[string]string{"secret_key": "status.atProvider.secretKey"}
 }
 
 // GetObservation of this Key

--- a/apis/namespaced/objectstorage/v1alpha1/zz_key_types.go
+++ b/apis/namespaced/objectstorage/v1alpha1/zz_key_types.go
@@ -42,10 +42,6 @@ type KeyObservation struct {
 
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
-	// (Computed)  The IONOS Object Storage Secret key.
-	// The Object Storage Secret key.
-	SecretKey *string `json:"secretKey,omitempty" tf:"secret_key,omitempty"`
-
 	// [string] The UUID of the user owning the IONOS Object Storage Key.
 	// The ID of the user that owns the key.
 	UserID *string `json:"userId,omitempty" tf:"user_id,omitempty"`

--- a/apis/namespaced/objectstorage/v1alpha1/zz_storageaccesskey_terraformed.go
+++ b/apis/namespaced/objectstorage/v1alpha1/zz_storageaccesskey_terraformed.go
@@ -21,7 +21,7 @@ func (mg *StorageAccesskey) GetTerraformResourceType() string {
 
 // GetConnectionDetailsMapping for this StorageAccesskey
 func (tr *StorageAccesskey) GetConnectionDetailsMapping() map[string]string {
-	return nil
+	return map[string]string{"secretkey": "status.atProvider.secretkey"}
 }
 
 // GetObservation of this StorageAccesskey

--- a/apis/namespaced/objectstorage/v1alpha1/zz_storageaccesskey_types.go
+++ b/apis/namespaced/objectstorage/v1alpha1/zz_storageaccesskey_types.go
@@ -41,10 +41,6 @@ type StorageAccesskeyObservation struct {
 
 	// (Computed)  The ID (UUID) of the AccessKey.
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
-
-	// (Computed)  The secret key of the Access key.
-	// The secret key of the Access key.
-	Secretkey *string `json:"secretkey,omitempty" tf:"secretkey,omitempty"`
 }
 
 type StorageAccesskeyParameters struct {

--- a/config/cluster/objectstorage/config.go
+++ b/config/cluster/objectstorage/config.go
@@ -84,8 +84,30 @@ func Configure(p *config.Provider) {
 		r.References["user_id"] = config.Reference{
 			TerraformName: "ionoscloud_user",
 		}
+		// Not marked sensitive upstream; without this the credential is
+		// published in plain text under status.atProvider.
+		r.TerraformResource.Schema["secret_key"].Sensitive = true
+		// The resource ID is the S3 access key; publish it with the secret.
+		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
+			conn := map[string][]byte{}
+			if id, ok := attr["id"].(string); ok && id != "" {
+				conn["accesskey"] = []byte(id)
+			}
+			return conn, nil
+		}
 	})
 	p.AddResourceConfigurator("ionoscloud_object_storage_accesskey", func(r *config.Resource) {
 		r.ShortGroup = storage
+		// Not marked sensitive upstream; without this the credential is
+		// published in plain text under status.atProvider.
+		r.TerraformResource.Schema["secretkey"].Sensitive = true
+		// Publish the access key alongside the secret key.
+		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
+			conn := map[string][]byte{}
+			if accesskey, ok := attr["accesskey"].(string); ok && accesskey != "" {
+				conn["accesskey"] = []byte(accesskey)
+			}
+			return conn, nil
+		}
 	})
 }

--- a/config/namespaced/objectstorage/config.go
+++ b/config/namespaced/objectstorage/config.go
@@ -84,8 +84,30 @@ func Configure(p *config.Provider) {
 		r.References["user_id"] = config.Reference{
 			TerraformName: "ionoscloud_user",
 		}
+		// Not marked sensitive upstream; without this the credential is
+		// published in plain text under status.atProvider.
+		r.TerraformResource.Schema["secret_key"].Sensitive = true
+		// The resource ID is the S3 access key; publish it with the secret.
+		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
+			conn := map[string][]byte{}
+			if id, ok := attr["id"].(string); ok && id != "" {
+				conn["accesskey"] = []byte(id)
+			}
+			return conn, nil
+		}
 	})
 	p.AddResourceConfigurator("ionoscloud_object_storage_accesskey", func(r *config.Resource) {
 		r.ShortGroup = storage
+		// Not marked sensitive upstream; without this the credential is
+		// published in plain text under status.atProvider.
+		r.TerraformResource.Schema["secretkey"].Sensitive = true
+		// Publish the access key alongside the secret key.
+		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
+			conn := map[string][]byte{}
+			if accesskey, ok := attr["accesskey"].(string); ok && accesskey != "" {
+				conn["accesskey"] = []byte(accesskey)
+			}
+			return conn, nil
+		}
 	})
 }

--- a/package/crds/objectstorage.ionoscloud.io_keys.yaml
+++ b/package/crds/objectstorage.ionoscloud.io_keys.yaml
@@ -354,11 +354,6 @@ spec:
                     type: boolean
                   id:
                     type: string
-                  secretKey:
-                    description: |-
-                      (Computed)  The IONOS Object Storage Secret key.
-                      The Object Storage Secret key.
-                    type: string
                   userId:
                     description: |-
                       [string] The UUID of the user owning the IONOS Object Storage Key.

--- a/package/crds/objectstorage.ionoscloud.io_storageaccesskeys.yaml
+++ b/package/crds/objectstorage.ionoscloud.io_storageaccesskeys.yaml
@@ -212,11 +212,6 @@ spec:
                   id:
                     description: (Computed)  The ID (UUID) of the AccessKey.
                     type: string
-                  secretkey:
-                    description: |-
-                      (Computed)  The secret key of the Access key.
-                      The secret key of the Access key.
-                    type: string
                 type: object
               conditions:
                 description: Conditions of the resource.

--- a/package/crds/objectstorage.m.ionoscloud.io_keys.yaml
+++ b/package/crds/objectstorage.m.ionoscloud.io_keys.yaml
@@ -324,11 +324,6 @@ spec:
                     type: boolean
                   id:
                     type: string
-                  secretKey:
-                    description: |-
-                      (Computed)  The IONOS Object Storage Secret key.
-                      The Object Storage Secret key.
-                    type: string
                   userId:
                     description: |-
                       [string] The UUID of the user owning the IONOS Object Storage Key.

--- a/package/crds/objectstorage.m.ionoscloud.io_storageaccesskeys.yaml
+++ b/package/crds/objectstorage.m.ionoscloud.io_storageaccesskeys.yaml
@@ -170,11 +170,6 @@ spec:
                   id:
                     description: (Computed)  The ID (UUID) of the AccessKey.
                     type: string
-                  secretkey:
-                    description: |-
-                      (Computed)  The secret key of the Access key.
-                      The secret key of the Access key.
-                    type: string
                 type: object
               conditions:
                 description: Conditions of the resource.


### PR DESCRIPTION
### Description of your changes

Fixes #72

`Key` (`ionoscloud_s3_key`) and `StorageAccesskey` (`ionoscloud_object_storage_accesskey`) never produced connection details: the Secret referenced by `spec.writeConnectionSecretToRef` stayed empty while the S3 credentials were published in plain text under `status.atProvider` (`secretKey`, resp. `accesskey`/`secretkey`).

Root cause: the upstream Terraform provider does not mark `secret_key`/`secretkey` as `Sensitive` (reported upstream as ionos-cloud/terraform-provider-ionoscloud#1026), and upjet routes attributes to connection secrets based on that flag — so `GetConnectionDetailsMapping()` was generated as `nil`.

This PR marks both attributes as sensitive in the upjet configuration (`config/{cluster,namespaced}/objectstorage/config.go`), which:

- removes `secretKey`/`secretkey` from the CR status, and
- publishes them to the connection secret as `attribute.secret_key` / `attribute.secretkey`.

It additionally publishes the matching access key via `Sensitive.AdditionalConnectionDetailsFn` — the `Key` resource ID, resp. the `accesskey` attribute — under the `accesskey` key, so the connection secret contains a complete, directly consumable credential pair. (`accesskey` itself remains visible in status/external-name; it is the secret half that is removed.)

All other changes are `make generate` output (4 CRDs + generated types).

###  Breaking change — please call out in release notes

`status.atProvider.secretKey` (`Key`, both API groups) and `status.atProvider.secretkey` (`StorageAccesskey`, both API groups) are **removed**. Users currently reading the credential from status (e.g. via Terraform data sources or scripts) must switch to the connection secret (`spec.writeConnectionSecretToRef` / `spec.publishConnectionDetailsTo`). This is the intended security behavior — credentials should never be world-readable in status — but it is a behavioral break for existing consumers.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make generate`, `go build ./... && go test ./...`, and golangci-lint v2.11.0 (the version CI uses) — all clean. Note: local `make lint` is currently broken on the `v2` branch independent of this PR (the Makefile pins `GOLANGCILINT_VERSION ?= 1.54.0` while `.golangci.yml` uses the `version: "2"` config format).

### How has this code been tested

- `make generate` — the diff is exactly the four objectstorage CRDs/types: secret fields dropped from the Observation structs, `GetConnectionDetailsMapping()` now returns the sensitive-attribute mapping.
- `go build ./...`, `go test ./...`, golangci-lint v2.11.0: pass, 0 issues.
- Behavior observed on provider v0.5.7 / Crossplane 2.3.4 / k3s: empty `connection.crossplane.io/v1alpha1` Secret, plaintext key material in status for both API groups.

[contribution process]: https://git.io/fj2m9
